### PR TITLE
행렬에 저장된 값을 일반 변수에 저장하도록 하는 기능.

### DIFF
--- a/src/listener/main/BytecodeGenListener.java
+++ b/src/listener/main/BytecodeGenListener.java
@@ -346,9 +346,9 @@ public class BytecodeGenListener extends MiniCBaseListener implements ParseTreeL
             	int arr_decl_child = ctx.arr_decl().getChildCount();		//count '[]'
             	for (int i =0 ;i < arr_decl_child-1; i++) {
             		String current_index = ctx.arr_decl().getChild(i).getChild(1).getText();	//arr_decl()은 [ Literal ]이기 때문에 getText()써도 됨.
-            		expr += "iconst " + current_index + "\naaload\n";
+            		expr += "iconst_" + current_index + "\naaload\n";
             	}
-            	expr += "iconst " + ctx.arr_decl().getChild(arr_decl_child-1).getChild(1).getText() +"\n" + newTexts.get(ctx.expr(0)) 
+            	expr += "iconst_" + ctx.arr_decl().getChild(arr_decl_child-1).getChild(1).getText() +"\n" + newTexts.get(ctx.expr(0)) 
             			+ "iastore\n";
             } else { // expr
                 // Arrays: TODO

--- a/src/listener/main/BytecodeGenListenerHelper.java
+++ b/src/listener/main/BytecodeGenListenerHelper.java
@@ -45,9 +45,9 @@ public class BytecodeGenListenerHelper {
 	static int initVal(Local_declContext ctx) {
 		return Integer.parseInt(ctx.LITERAL().getText());
 	}
-
-	static boolean isArrayDecl(Local_declContext ctx) {
-		return ctx.getChildCount() == 6;
+	//수정 - 김예원 19-12-14
+	static boolean isArrayDecl(Local_declContext ctx) {	//길이가 아닌 arr_decl()의 존재여부로 True or False 리턴
+		return ctx.arr_decl() != null;
 	}
 	
 	static boolean isDeclWithInit(Local_declContext ctx) {


### PR DESCRIPTION
--커밋 : assign array's value to variable
a= t[1][2][3]이렇게 있으면
aload 2              //2는 t의 varID
ldc 1 
aaload 
ldc 2 
aaload 
ldc 3
iaload 
istore 1           //1은 a의 varID

그리고 기존 행렬은 t[1][2][3]이 varName으로 저장되었음
현재는 t[1][2][3]이 있으면 t가 varName으로 저장하도록 변경하였음.

======================================

--커밋 : assign expr value to array
변수 expr의 값을 array에 저장하는 기능을 추가
t[1][2][3] = 14이렇게 있으면
aload 2      //2는 t의 varID
iconst 1
aaload
iconst 2
aaload
iconst 3
ldc 14      //14는 저장할 값
iastore